### PR TITLE
Update Utilities.vala - Add file path lookup for gstreamer to allow video wallpapers on ARM devices such as Raspberry Pi.

### DIFF
--- a/src/Utilities.vala
+++ b/src/Utilities.vala
@@ -370,7 +370,8 @@ namespace Komorebi.Utilities {
 		if(	File.new_for_path("/usr/lib/gstreamer-1.0/libgstlibav.so").query_exists() ||
 			File.new_for_path("/usr/lib64/gstreamer-1.0/libgstlibav.so").query_exists() ||
 			File.new_for_path("/usr/lib/i386-linux-gnu/gstreamer-1.0/libgstlibav.so").query_exists() ||
-			File.new_for_path("/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so").query_exists())
+			File.new_for_path("/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so").query_exists() ||
+			File.new_for_path("/usr/lib/arm-linux-gnueabihf/gstreamer-1.0/libgstlibav.so").query_exists())
 			return true;
 
 		return false;


### PR DESCRIPTION
Adding path for gstreamer1.0-libav path lookup, to validate video capabilities. Found this limitation while attempting to add this to a Raspberry Pi.